### PR TITLE
Fix OWASP dependency checker by upgrading plugin

### DIFF
--- a/online-devops-dojo/shift-security-left/step5-nospell.md
+++ b/online-devops-dojo/shift-security-left/step5-nospell.md
@@ -12,7 +12,7 @@
              &lt;plugin&gt;
                 &lt;groupId&gt;org.owasp&lt;/groupId&gt;
                 &lt;artifactId&gt;dependency-check-maven&lt;/artifactId&gt;
-                &lt;version&gt;3.3.2&lt;/version&gt;
+                &lt;version&gt;5.2.4&lt;/version&gt;
                 &lt;configuration&gt;
                     &lt;format&gt;ALL&lt;/format&gt;
                     &lt;failBuildOnCVSS&gt;7&lt;/failBuildOnCVSS&gt;


### PR DESCRIPTION
This fixes the OWASP dependency checker target in maven, which was broken because of the XML feed being replaced by json feed.
Updating the plugin version fixes that.