### PR TITLE
Disable default sec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ each time you push updates to your repository.
    * _Key_: paste the _Git Deploy Key_ value from your Katacoda settings page
    * _Allow write access_: leave unchecked
 4. Click on _Add deploy key_ button
-5. Click on _Hooks_ (left navigation)
+5. Click on _Webhooks_ (left navigation)
 6. Click on _Add webhook_ button and use the following information to set it up:
    * _Payload URL_: [https://editor.katacoda.com/scenarios/updated](https://editor.katacoda.com/scenarios/updated)
    * _Content type_: `application/json`

--- a/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
+++ b/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
@@ -61,21 +61,22 @@ check_credentials
 # Copy the repository template https://github.com/dxc-technology/pet-clinic to the user
 pet_clinic_copy()
 {
-  echo -e "${COLINFO}Copying $REPO Git repository to user's account ..${COLRESET}"
+  echo -e "${COLINFO}Copying $REPO repository to user's account ..${COLRESET}"
   echo -e "${COLLOGS}"
 
   # node_id of the repository https://github.com/dxc-technology/pet-clinic
-  TEMPLATE_ID = "MDEwOlJlcG9zaXRvcnkyMDM2MDcwNTA="
+  TEMPLATE_ID="MDEwOlJlcG9zaXRvcnkyMDM2MDcwNTA="
+
   # Clone the template repository
-  curl --location --request POST '$GITHUBAPIURL/graphql' \
+  curl --location --request POST $GITHUBAPIURL/graphql \
     --header 'Content-Type: application/json' \
-    --header 'Authorization: token $TOKEN' \
+    --header "Authorization: token $TOKEN" \
     --header 'Cookie: logged_in=no' \
-    --data-raw '{"query":"mutation clonePetClinic {\r\n  cloneTemplateRepository(input: {name: \"$REPO\", ownerId: \"$USER_NODE_ID\", repositoryId: \"$TEMPLATE_ID\", visibility: PUBLIC }) {\r\n    repository {\r\n      name\r\n    }\r\n  }\r\n}","variables":{}}'
+    --data-raw '{"query":"mutation clonePetClinic { cloneTemplateRepository(input: {name: \"'$REPO'\", ownerId: \"'$USER_NODE_ID'\", repositoryId: \"'$TEMPLATE_ID'\", visibility: PUBLIC }) { repository { name } } }","variables":{}}'
   # Disable vulnerability alerts
-  curl --location --request DELETE '$GITHUBAPIURL/repos/$SHORTNAME/$REPO/vulnerability-alerts' \
+  curl --location --request DELETE $GITHUBAPIURL/repos/$SHORTNAME/$REPO/vulnerability-alerts \
     --header 'Accept: application/vnd.github.dorian-preview+json' \
-    --header 'Authorization: token $TOKEN' \
+    --header "Authorization: token $TOKEN" \
     --header 'Cookie: logged_in=no'
 }
 


### PR DESCRIPTION
Disable security check which conflicts with shift security left training vulnerabilities.

The graphQL mutation to clone the template worked fine but if the repository is deleted, a second clone attempt makes the API answers that the repository still exist and conflicts. Bug or delay annoying for testing.

I reverted back to local clone method.