### PR TITLE
if .email is null then do not return the string 'null'

### DIFF
--- a/online-devops-dojo/continuous-integration/assets/prepare.sh
+++ b/online-devops-dojo/continuous-integration/assets/prepare.sh
@@ -35,7 +35,7 @@ export SHORTNAME
 echo $SHORTNAME > /tmp/shortname.txt
 echo $TOKEN >> /tmp/shortname.txt
 
-EMAIL=$(echo $USER_JSON | jq -r '.email')
+EMAIL=$(echo $USER_JSON | jq -r '.email//empty')
 if [ -z "$EMAIL" ]; then
   EMAIL=${SHORTNAME}@noemail.com
 fi

--- a/online-devops-dojo/shift-security-left/assets/prepare.sh
+++ b/online-devops-dojo/shift-security-left/assets/prepare.sh
@@ -37,7 +37,7 @@ export SHORTNAME
 echo $SHORTNAME > /tmp/shortname.txt
 echo $TOKEN >> /tmp/shortname.txt
 
-EMAIL=$(echo $USER_JSON | jq -r '.email')
+EMAIL=$(echo $USER_JSON | jq -r '.email//empty')
 if [ -z "$EMAIL" ]; then
   EMAIL=${SHORTNAME}@noemail.com
 fi

--- a/online-devops-dojo/version-control/assets/prepare.sh
+++ b/online-devops-dojo/version-control/assets/prepare.sh
@@ -33,7 +33,7 @@ SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
 echo "export SHORTNAME=${SHORTNAME}" > /tmp/shortname.txt
 
-EMAIL=$(echo $USER_JSON | jq -r '.email')
+EMAIL=$(echo $USER_JSON | jq -r '.email//empty')
 if [ -z "$EMAIL" ]; then
   EMAIL=${SHORTNAME}@noemail.com
 fi

--- a/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
+++ b/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
@@ -36,7 +36,7 @@ USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "Accept: 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
 
-EMAIL=$(echo $USER_JSON | jq -r '.email')
+EMAIL=$(echo $USER_JSON | jq -r '.email//empty')
 if [ -z "$EMAIL" ]; then
   EMAIL=${SHORTNAME}@noemail.com
 fi


### PR DESCRIPTION
## Proposed changes

This is a small fix for the case that a user does not have an email address defined in his github profile. In that case the json from the github api contains `"email": null` which was not correctly handled by the script. The `jq -r '.email'` command returns the string `"null"` and with this fix it returns an empty string (as intended).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
