### PR TITLE
allow PAT input without echo

### DIFF
--- a/online-devops-dojo/continuous-integration/assets/index.html
+++ b/online-devops-dojo/continuous-integration/assets/index.html
@@ -3,7 +3,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.min.css">
+        href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css">
     <style>
         .markdown-body {
             box-sizing: border-box;

--- a/online-devops-dojo/continuous-integration/assets/prepare.sh
+++ b/online-devops-dojo/continuous-integration/assets/prepare.sh
@@ -19,12 +19,16 @@ if [ "$DEBUG" = false ] ; then
   CURL_NODEBUG="-sS"
 fi
 
+# adding -s to the command line, allows to hide the PAT entered especially during demos
+if [ "$1" == "-s" ] ; then
+  HIDE_PAT="-s"
+fi
 
 #
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read TOKEN
+read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"

--- a/online-devops-dojo/continuous-integration/assets/prepare.sh
+++ b/online-devops-dojo/continuous-integration/assets/prepare.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -5,10 +6,10 @@
 # Globals
 #
 DEBUG=false
-GITHUB="github.com"
-GITHUBAPIURL="https://api.github.com"
+GITHUB='github.com'
+GITHUBAPIURL='https://api.github.com'
 # Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
-GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+GITHUBAPIHEADER='Accept: application/vnd.github.v3+json'
 
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
@@ -31,11 +32,11 @@ fi
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read ${HIDE_PAT} TOKEN
+read $HIDE_PAT TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -52,7 +53,7 @@ git config --global user.email "${EMAIL}"
 
 # Check if repository already exists and properly populated
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
   echo -e "${COLRESET}> I'm confused..."
@@ -82,7 +83,7 @@ docker run --name nginx -p 9876:80 -v /root/nginx:/usr/share/nginx/html:ro -d ng
 #
 echo -e "${COLINFO}Configuring your GitHub $REPO repository...${COLRESET}"
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
 
 filename="ids.txt"
 
@@ -91,7 +92,7 @@ remove_existing_webhook()
 while read -r line
 do
     name="$line"
-        curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
+        curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
 done < "$filename"
 }
 remove_existing_webhook
@@ -118,7 +119,7 @@ echo -e "${COLINFO}Updating GitHub web hook to point to Katacoda Jenkins...${COL
 echo -e "${COLLOGS}"
 JenkinsUrl=`curl ${CURL_NODEBUG} "https://katacoda.com/metadata/generate-url?port=8080&ip=$(ip addr show ens3 | grep -Po 'inet \K[\d.]+')"`
 
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
 }
 adding_webhook
 

--- a/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
+++ b/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # Globals
 #
 DEBUG=false
-GITHUB="github.com"
-GITHUBAPIURL="https://api.github.com"
+GITHUB='github.com'
+GITHUBAPIURL='https://api.github.com'
 # Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
-GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+GITHUBAPIHEADER='Accept: application/vnd.github.v3+json'
 
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
@@ -33,12 +35,12 @@ fi
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read ${HIDE_PAT} TOKEN
+read $HIDE_PAT TOKEN
 export TOKEN
 
 check_credentials()
 {
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL} | grep "current_user_url"
+  curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL} | grep "current_user_url"
   CREDS_NOT_OK=$?
   if [ $CREDS_NOT_OK -ne 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. Please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
@@ -48,7 +50,7 @@ check_credentials()
 check_credentials
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME

--- a/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
+++ b/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
@@ -6,6 +6,9 @@
 DEBUG=false
 GITHUB="github.com"
 GITHUBAPIURL="https://api.github.com"
+# Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
+GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
 COLLOGS="\u001b[35m"
@@ -35,7 +38,7 @@ export TOKEN
 
 check_credentials()
 {
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL} | grep "current_user_url"
+  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL} | grep "current_user_url"
   CREDS_NOT_OK=$?
   if [ $CREDS_NOT_OK -ne 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. Please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
@@ -45,7 +48,7 @@ check_credentials()
 check_credentials
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME

--- a/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
+++ b/online-devops-dojo/devops-kaizen/assets/add.improvement.to.backlog.sh
@@ -21,11 +21,16 @@ fi
 echo -e "${COLINFO}Installing dependencies...${COLRESET}"
 2>/dev/null 1>/dev/null python3 -m pip install pyyaml requests
 
+# adding -s to the command line, allows to hide the PAT entered especially during demos
+if [ "$1" == "-s" ] ; then
+  HIDE_PAT="-s"
+fi
+
 #
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read TOKEN
+read ${HIDE_PAT} TOKEN
 export TOKEN
 
 check_credentials()

--- a/online-devops-dojo/devops-kaizen/assets/github-issues.py
+++ b/online-devops-dojo/devops-kaizen/assets/github-issues.py
@@ -13,7 +13,7 @@ COLINFO="\033[0;35m"
 COLRESET="\033[m"
 
 baseurl = 'https://api.github.com'
-headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.symmetra-preview+json", "Accept": "application/vnd.github.v3+json"}
+headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.v3+json"}
 user = os.environ['SHORTNAME']
 token = os.environ['TOKEN']
 repo = user + '/pet-clinic'
@@ -73,6 +73,4 @@ def main():
                 sys.stdout.flush()
     print(COLRESET)
 
-
 main()
-

--- a/online-devops-dojo/shift-security-left/assets/prepare.sh
+++ b/online-devops-dojo/shift-security-left/assets/prepare.sh
@@ -18,6 +18,7 @@ if [ "$DEBUG" = false ] ; then
   CURL_NODEBUG="-sS"
 fi
 
+# adding -s to the command line, allows to hide the PAT entered especially during demos
 if [ "$1" == "-s" ] ; then
   HIDE_PAT="-s"
 fi
@@ -64,7 +65,7 @@ fi
 KatacodaJenkinsUrl=`curl ${CURL_NODEBUG} "https://katacoda.com/metadata/generate-url?port=8080&ip=$(ip addr show ens3 | grep -Po 'inet \K[\d.]+')"`
 url="https://${KatacodaJenkinsUrl}"
 echo $url >> /tmp/shortname.txt
-#
+
 # 
 # Clone Pet Clinic locally
 #

--- a/online-devops-dojo/shift-security-left/assets/prepare.sh
+++ b/online-devops-dojo/shift-security-left/assets/prepare.sh
@@ -7,6 +7,9 @@
 DEBUG=false
 GITHUB="github.com"
 GITHUBAPIURL="https://api.github.com"
+# Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
+GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
 COLLOGS="\u001b[35m"
@@ -31,7 +34,7 @@ read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -48,7 +51,7 @@ git config --global user.email "${EMAIL}"
 
 # Check if repository already exists and properly populated
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
   echo -e "${COLRESET}> I'm confused..."
@@ -81,7 +84,7 @@ echo -e "${COLRESET}"
 #
 echo -e "${COLINFO}Configuring your GitHub $REPO repository...${COLRESET}"
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
+curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
 
 
 filename="ids.txt"
@@ -91,7 +94,7 @@ remove_existing_webhook()
 while read -r line
 do
     name="$line"
-        curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
+        curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
 done < "$filename"
 }
 remove_existing_webhook
@@ -117,7 +120,7 @@ echo -e "${COLINFO}Updating GitHub web hook to point to Katacoda Jenkins...${COL
 echo -e "${COLLOGS}"
 JenkinsUrl=`curl ${CURL_NODEBUG} "https://katacoda.com/metadata/generate-url?port=8080&ip=$(ip addr show ens3 | grep -Po 'inet \K[\d.]+')"`
 
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
+curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
 }
 adding_webhook
 

--- a/online-devops-dojo/shift-security-left/assets/prepare.sh
+++ b/online-devops-dojo/shift-security-left/assets/prepare.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -5,10 +6,10 @@
 # Globals
 #
 DEBUG=false
-GITHUB="github.com"
-GITHUBAPIURL="https://api.github.com"
+GITHUB='github.com'
+GITHUBAPIURL='https://api.github.com'
 # Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
-GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+GITHUBAPIHEADER='Accept: application/vnd.github.v3+json'
 
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
@@ -30,11 +31,11 @@ fi
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read ${HIDE_PAT} TOKEN
+read $HIDE_PAT TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -51,7 +52,7 @@ git config --global user.email "${EMAIL}"
 
 # Check if repository already exists and properly populated
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
   echo -e "${COLRESET}> I'm confused..."
@@ -84,7 +85,7 @@ echo -e "${COLRESET}"
 #
 echo -e "${COLINFO}Configuring your GitHub $REPO repository...${COLRESET}"
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks | jq -r '.[] .id' > ids.txt
 
 
 filename="ids.txt"
@@ -94,7 +95,7 @@ remove_existing_webhook()
 while read -r line
 do
     name="$line"
-        curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
+    curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X DELETE ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks/"$line"
 done < "$filename"
 }
 remove_existing_webhook
@@ -120,7 +121,7 @@ echo -e "${COLINFO}Updating GitHub web hook to point to Katacoda Jenkins...${COL
 echo -e "${COLLOGS}"
 JenkinsUrl=`curl ${CURL_NODEBUG} "https://katacoda.com/metadata/generate-url?port=8080&ip=$(ip addr show ens3 | grep -Po 'inet \K[\d.]+')"`
 
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X POST --data '{"name": "web","active": true,"events": [ "push", "pull_request" ], "config":{"url": "https://'"$JenkinsUrl"'/github-webhook/","content_type":"json"}}' ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/hooks
 }
 adding_webhook
 

--- a/online-devops-dojo/version-control/assets/prepare.sh
+++ b/online-devops-dojo/version-control/assets/prepare.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -5,10 +6,10 @@
 # Globals
 #
 DEBUG=false
-GITHUB="github.com"
-GITHUBAPIURL="https://api.github.com"
+GITHUB='github.com'
+GITHUBAPIURL='https://api.github.com'
 # Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
-GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+GITHUBAPIHEADER='Accept: application/vnd.github.v3+json'
 
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
@@ -31,11 +32,11 @@ fi
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read ${HIDE_PAT} TOKEN
+read $HIDE_PAT TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -51,7 +52,7 @@ git config --global user.email "${EMAIL}"
 
 # Check if repository already exists and properly populated
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
   echo -e "${COLRESET}> I'm confused..."

--- a/online-devops-dojo/version-control/assets/prepare.sh
+++ b/online-devops-dojo/version-control/assets/prepare.sh
@@ -7,6 +7,9 @@
 DEBUG=false
 GITHUB="github.com"
 GITHUBAPIURL="https://api.github.com"
+# Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
+GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
 COLLOGS="\u001b[35m"
@@ -32,7 +35,7 @@ read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -48,7 +51,7 @@ git config --global user.email "${EMAIL}"
 
 # Check if repository already exists and properly populated
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
   echo -e "${COLRESET}> I'm confused..."

--- a/online-devops-dojo/version-control/assets/prepare.sh
+++ b/online-devops-dojo/version-control/assets/prepare.sh
@@ -19,11 +19,16 @@ if [ "$DEBUG" = false ] ; then
   CURL_NODEBUG="-sS"
 fi
 
+# adding -s to the command line, allows to hide the PAT entered especially during demos
+if [ "$1" == "-s" ] ; then
+  HIDE_PAT="-s"
+fi
+
 #
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please enter your ${GITHUB} Personal Access Token:${COLRESET}"
-read TOKEN
+read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"

--- a/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
+++ b/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
@@ -8,6 +8,9 @@
 DEBUG=false
 GITHUB="github.com"
 GITHUBAPIURL="https://api.github.com"
+# Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
+GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
 COLLOGS="\u001b[35m"
@@ -36,7 +39,7 @@ read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -50,7 +53,7 @@ git config --global user.email "${EMAIL}"
 
 check_credentials()
 {
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL} | grep "current_user_url"
+  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL} | grep "current_user_url"
   CREDS_NOT_OK=$?
   if [ $CREDS_NOT_OK -ne 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. Please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
@@ -79,6 +82,7 @@ pet_clinic_copy()
 
   # Disable vulnerability alerts
   curl --location --request DELETE $GITHUBAPIURL/repos/$SHORTNAME/$REPO/vulnerability-alerts \
+    --header ${GITHUBAPIHEADER} \
     --header 'Accept: application/vnd.github.dorian-preview+json' \
     --header "Authorization: token $TOKEN" \
     --header 'Cookie: logged_in=no'
@@ -91,17 +95,17 @@ pet_clinic_copy()
 
 # Check if user repository already exists
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X POST --data "{\"name\":\"${REPO}\"}" ${GITHUBAPIURL}/user/repos | grep "Not Found"
+  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X POST --data "{\"name\":\"${REPO}\"}" ${GITHUBAPIURL}/user/repos | grep "Not Found"
   USER_HAS_NO_ACCESS_TO_REPO=$?
   if [ $USER_HAS_NO_ACCESS_TO_REPO -eq 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. As per the instructions please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
     exit 1
   fi
  
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET ${GITHUBAPIURL}/repos/${ORGREPO}/${REPO} | grep "Not Found"
+  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/${ORGREPO}/${REPO} | grep "Not Found"
   PETCLINIC_NOT_AVAILABLE=$?
   if [ $PETCLINIC_NOT_AVAILABLE -eq 0 ]; then
     echo -e "${COLQUESTION}Error: a ressource is missing for the scenario to execute. Please submit an issue to https://${GITHUB}/${ORGREPO}/online-devops-dojo/issues .${COLRESET}"

--- a/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
+++ b/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
@@ -6,10 +6,10 @@
 # Globals
 #
 DEBUG=false
-GITHUB="github.com"
-GITHUBAPIURL="https://api.github.com"
+GITHUB='github.com'
+GITHUBAPIURL='https://api.github.com'
 # Explicit header for GitHub API V3 request cf. https://developer.github.com/v3/#current-version
-GITHUBAPIHEADER="Accept: application/vnd.github.v3+json"
+GITHUBAPIHEADER='Accept: application/vnd.github.v3+json'
 
 COLQUESTION="\u001b[36m"
 COLINFO="\u001b[37m"
@@ -35,11 +35,11 @@ fi
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please create and enter a Personal Access Token from ${GITHUB} at https://${GITHUB}/settings/tokens:${COLRESET}"
-read ${HIDE_PAT} TOKEN
+read $HIDE_PAT TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"
-USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/user)
+USER_JSON=$(curl ${CURL_NODEBUG} -H "Authorization: token ${TOKEN}" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/user)
 
 SHORTNAME=$(echo $USER_JSON | jq -r '.login')
 export SHORTNAME
@@ -53,7 +53,7 @@ git config --global user.email "${EMAIL}"
 
 check_credentials()
 {
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL} | grep "current_user_url"
+  curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL} | grep "current_user_url"
   CREDS_NOT_OK=$?
   if [ $CREDS_NOT_OK -ne 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. Please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
@@ -82,7 +82,7 @@ pet_clinic_copy()
 
   # Disable vulnerability alerts
   curl --location --request DELETE $GITHUBAPIURL/repos/$SHORTNAME/$REPO/vulnerability-alerts \
-    --header ${GITHUBAPIHEADER} \
+    --header "$GITHUBAPIHEADER" \
     --header 'Accept: application/vnd.github.dorian-preview+json' \
     --header "Authorization: token $TOKEN" \
     --header 'Cookie: logged_in=no'
@@ -95,17 +95,17 @@ pet_clinic_copy()
 
 # Check if user repository already exists
 echo -e "${COLLOGS}"
-curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
+curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/$SHORTNAME/$REPO/contents/Jenkinsfile | grep "Not Found"
 REPO_DOES_NOT_EXIST=$?
 if [ $REPO_DOES_NOT_EXIST -eq 0 ]; then
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X POST --data "{\"name\":\"${REPO}\"}" ${GITHUBAPIURL}/user/repos | grep "Not Found"
+  curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X POST --data "{\"name\":\"${REPO}\"}" ${GITHUBAPIURL}/user/repos | grep "Not Found"
   USER_HAS_NO_ACCESS_TO_REPO=$?
   if [ $USER_HAS_NO_ACCESS_TO_REPO -eq 0 ]; then
     echo -e "${COLQUESTION}Error: it seems that your credentials are invalid. As per the instructions please use your GitHub user account and a Personal Access Token with 'repo' and 'admin:repo_hook' scopes at https://github.com/settings/tokens/new ${COLRESET}"
     exit 1
   fi
  
-  curl ${CURL_NODEBUG} -H "Authorization: token $TOKEN" -H ${GITHUBAPIHEADER} -X GET ${GITHUBAPIURL}/repos/${ORGREPO}/${REPO} | grep "Not Found"
+  curl $CURL_NODEBUG -H "Authorization: token $TOKEN" -H "$GITHUBAPIHEADER" -X GET ${GITHUBAPIURL}/repos/${ORGREPO}/${REPO} | grep "Not Found"
   PETCLINIC_NOT_AVAILABLE=$?
   if [ $PETCLINIC_NOT_AVAILABLE -eq 0 ]; then
     echo -e "${COLQUESTION}Error: a ressource is missing for the scenario to execute. Please submit an issue to https://${GITHUB}/${ORGREPO}/online-devops-dojo/issues .${COLRESET}"

--- a/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
+++ b/online-devops-dojo/welcome/assets/copy-pet-clinic.sh
@@ -23,11 +23,16 @@ fi
 echo -e "${COLINFO}Installing dependencies...${COLRESET}"
 2>/dev/null 1>/dev/null python3 -m pip install pyyaml requests
 
+# adding -s to the command line, allows to hide the PAT entered especially during demos
+if [ "$1" == "-s" ] ; then
+  HIDE_PAT="-s"
+fi
+
 #
 # Ask for GitHub PAT
 #
 echo -e "${COLQUESTION}Please create and enter a Personal Access Token from ${GITHUB} at https://${GITHUB}/settings/tokens:${COLRESET}"
-read TOKEN
+read ${HIDE_PAT} TOKEN
 export TOKEN
 
 echo -e "${COLLOGS}Fetching your details from GitHub...${COLRESET}"

--- a/online-devops-dojo/welcome/assets/github-issues.py
+++ b/online-devops-dojo/welcome/assets/github-issues.py
@@ -13,7 +13,7 @@ COLINFO="\033[0;35m"
 COLRESET="\033[m"
 
 baseurl = 'https://api.github.com'
-headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.symmetra-preview+json", "Accept": "application/vnd.github.v3+json"}
+headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.v3+json"}
 user = os.environ['SHORTNAME']
 token = os.environ['TOKEN']
 repo = user + '/pet-clinic'
@@ -36,7 +36,7 @@ def main():
     
     # Create the issues
     for issue in issues:
-        # Avoid creating an issue which is already there (same title) 
+        # Avoid creating an issue which is already there (same title)
         issue_already_exists = False
         # List all open issues
         payload = json.dumps({
@@ -44,9 +44,9 @@ def main():
             })
         sys.stdout.write(COLINFO + "." + COLRESET)
         sys.stdout.flush()
-        response = requests.get(baseurl + "/repos/" + repo + "/issues", 
-            data=payload, 
-            headers=headers, 
+        response = requests.get(baseurl + "/repos/" + repo + "/issues",
+            data=payload,
+            headers=headers,
             auth=(user, token))
         if response.status_code == 200:
             issues_opened = json.loads(response.text)
@@ -73,6 +73,4 @@ def main():
                 sys.stdout.flush()
     print(COLRESET)
 
-
 main()
-

--- a/online-devops-dojo/welcome/assets/github-labels.py
+++ b/online-devops-dojo/welcome/assets/github-labels.py
@@ -13,7 +13,7 @@ COLINFO="\033[0;35m"
 COLRESET="\033[m"
 
 baseurl = 'https://api.github.com'
-headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.symmetra-preview+json", "Accept": "application/vnd.github.v3+json"}
+headers = {"Content-Type": "application/json", "Accept": "application/vnd.github.v3+json"}
 user = os.environ['SHORTNAME']
 token = os.environ['TOKEN']
 repo = user + '/pet-clinic'
@@ -69,9 +69,9 @@ def main():
             "description": label['description'],
             "color" : label['color']
             })
-        response = requests.post(baseurl + "/repos/" + repo + "/labels", 
-            data=payload, 
-            headers=headers, 
+        response = requests.post(baseurl + "/repos/" + repo + "/labels",
+            data=payload,
+            headers=headers,
             auth=(user, token))
         if response.status_code != 201:
             # An error occured


### PR DESCRIPTION
## Proposed changes

In every module where PAT is requested, adding -s like
 `prepare.sh -s`
 or `add.improvement.to.backlog.sh -s`

will remove the echo, which is useful when sharing the screen.
The default click on the command on the left side is unchanged (doesn't add -s) since most people need to see what they type.

Resolves #78 from Chris
## Types of changes

What types of changes does your code introduce to Online DevOps Dojo?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Workflow change
- [ ] Documentation update (if none of the other choices apply)
